### PR TITLE
Fix for 4 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "categories": ["editing", "language", "external"],
     "i18n" : ["en", "ro", "en-gb"],
     "dependencies"   : {
-        "request" : "~2.34.0",
+        "request" : "~2.74.0",
         "adm-zip" : "0.4.4",
         "q"       : "1.0.1",
         "glob"    : "3.2.9",


### PR DESCRIPTION
aem-brackets-extension currently has a 9 vulnerable dependency paths, introducing 6 different types of known vulnerabilities.

This PR fixes vulnerable dependencies.
- [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.
- [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.
- [Denial of Service (Event Loop Blocking)](https://snyk.io/vuln/npm:qs:20140806-1)vulnerability in the `qs` dependency.
- [Denial of Service (Memory Exhaustion)](https://snyk.io/vuln/npm:qs:20140806)vulnerability in the `qs` dependency

You can see [Snyk test report](https://snyk.io/test/github/Adobe-Marketing-Cloud/aem-brackets-extension) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade other dependencies as well.

Stay Secure,
The Snyk Team
